### PR TITLE
Axios Instance of Beccaccino exported on beccaccino singleton.

### DIFF
--- a/src/Beccaccino.ts
+++ b/src/Beccaccino.ts
@@ -9,8 +9,8 @@ export type EndpointMap = {
 
 export const defaultSession: string = uuid();
 
-class ReduxHttpClient {
-  private readonly axiosInstance: AxiosInstance;
+export class ReduxHttpClient {
+  public readonly axiosInstance: AxiosInstance;
   private readonly axiosConfiguration: AxiosRequestConfig;
   private readonly endpoints: Array<EndpointConfig>;
   public readonly bindedEndpoints: EndpointMap = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ import { beccaccino } from './Beccaccino';
 
 export const Beccaccino = {
   configure: beccaccino.configure,
+  getClientInstance: beccaccino.getClientInstance,
   getClient: beccaccino.getClient,
 };


### PR DESCRIPTION
One of the `beccaccino` internals `getClientInstance` who returns the `axios` instance was missing on exported singleton `Beccaccino`.

