### PR TITLE
Result selector with response checks

### DIFF
--- a/src/__tests__/integration.spec.ts
+++ b/src/__tests__/integration.spec.ts
@@ -169,7 +169,7 @@ describe('when http action is dispatched the middleware', () => {
       endpointName: 'getRequest',
     });
     expect(resultSelectorResponse).toEqual(
-      [{ id: 1, test: true }],
+      [{ id: 1, test: true }, undefined],
     );
     const errorSelectorResponse = errorSelector({
       state,

--- a/src/__tests__/integration.spec.ts
+++ b/src/__tests__/integration.spec.ts
@@ -2,6 +2,8 @@ import {
   Beccaccino,
   beccaccinoMiddleware,
   beccaccinoReducer,
+  resultSelector,
+  errorSelector,
   BECCACCINO_REDUCER_NAME,
 } from '../';
 
@@ -53,7 +55,7 @@ describe('when http action is dispatched the middleware', () => {
   const action2 = client.getRequest({ urlParams: { id: '5b589ccf3000000923fe500c' } });
 
   it('store first request result', async (done) => {
-    expect.assertions(1);
+    expect.assertions(3);
     store.dispatch(action1);
     await action1.execAsync;
     const state = store.getState();
@@ -89,11 +91,27 @@ describe('when http action is dispatched the middleware', () => {
         },
       },
     });
+    const resultSelectorResponse = resultSelector({
+      state,
+      endpointName: 'getRequest',
+      limit: -1,
+    });
+    const errorSelectorResponse = errorSelector({
+      state,
+      endpointName: 'getRequest',
+      limit: -1,
+    });
+    expect(resultSelectorResponse).toEqual(
+      [{ id: 1, test: true }],
+    );
+    expect(errorSelectorResponse).toEqual(
+      [{ error: false, response: { id: 1, test: true } }],
+    );
     done();
   });
 
   it('store the second request result', async (done) => {
-    expect.assertions(1);
+    expect.assertions(3);
     store.dispatch(action2);
     await action2.execAsync;
     const state = store.getState();
@@ -146,6 +164,23 @@ describe('when http action is dispatched the middleware', () => {
         },
       },
     });
+    const resultSelectorResponse = resultSelector({
+      state,
+      endpointName: 'getRequest',
+    });
+    expect(resultSelectorResponse).toEqual(
+      [{ id: 1, test: true }],
+    );
+    const errorSelectorResponse = errorSelector({
+      state,
+      endpointName: 'getRequest',
+    });
+    expect(errorSelectorResponse).toEqual(
+      [
+        { error: false, response: { id: 1, test: true } },
+         { error: true, response: { id: 2, test: true } },
+      ],
+    );
     done();
   });
 });

--- a/src/redux-http/__tests__/selectors.spec.ts
+++ b/src/redux-http/__tests__/selectors.spec.ts
@@ -223,7 +223,18 @@ describe('state selectors', () => {
     it('Returns all the results of endpoint', () => {
       const result = resultSelector({
         endpointName: 'testEndpoint',
-        state: baseState,
+        state: {
+          ...baseState,
+          [BECCACCINO_REDUCER_NAME]: {
+            ...baseState[BECCACCINO_REDUCER_NAME],
+            requestsMetadata: {
+              request1: {
+                isLoading: false,
+                success: true,
+              },
+            },
+          },
+        },
       });
       expect(result).toEqual([
         { data: ['test'] },
@@ -235,11 +246,11 @@ describe('state selectors', () => {
         ...baseState,
         [BECCACCINO_REDUCER_NAME]: {
           ...baseState[BECCACCINO_REDUCER_NAME],
-        },
-        requestsMetadata: {
-          request1: {
-            isLoading: false,
-            success: false,
+          requestsMetadata: {
+            request1: {
+              isLoading: false,
+              success: false,
+            },
           },
         },
       };
@@ -247,7 +258,7 @@ describe('state selectors', () => {
         endpointName: 'testEndpoint',
         state: testState,
       });
-      expect(result).toBeUndefined();
+      expect(result).toEqual([undefined]);
     });
 
     it('Does not return a result of endpoint if the endpoint is loading', () => {
@@ -255,10 +266,10 @@ describe('state selectors', () => {
         ...baseState,
         [BECCACCINO_REDUCER_NAME]: {
           ...baseState[BECCACCINO_REDUCER_NAME],
-        },
-        requestsMetadata: {
-          request1: {
-            isLoading: true,
+          requestsMetadata: {
+            request1: {
+              isLoading: true,
+            },
           },
         },
       };
@@ -266,7 +277,7 @@ describe('state selectors', () => {
         endpointName: 'testEndpoint',
         state: testState,
       });
-      expect(result).toBeUndefined();
+      expect(result).toEqual([undefined]);
     });
   });
 

--- a/src/redux-http/__tests__/selectors.spec.ts
+++ b/src/redux-http/__tests__/selectors.spec.ts
@@ -229,6 +229,45 @@ describe('state selectors', () => {
         { data: ['test'] },
       ]);
     });
+
+    it('Does not return a result of endpoint if the endpoint has an error', () => {
+      const testState = {
+        ...baseState,
+        [BECCACCINO_REDUCER_NAME]: {
+          ...baseState[BECCACCINO_REDUCER_NAME],
+        },
+        requestsMetadata: {
+          request1: {
+            isLoading: false,
+            success: false,
+          },
+        },
+      };
+      const result = resultSelector({
+        endpointName: 'testEndpoint',
+        state: testState,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('Does not return a result of endpoint if the endpoint is loading', () => {
+      const testState = {
+        ...baseState,
+        [BECCACCINO_REDUCER_NAME]: {
+          ...baseState[BECCACCINO_REDUCER_NAME],
+        },
+        requestsMetadata: {
+          request1: {
+            isLoading: true,
+          },
+        },
+      };
+      const result = resultSelector({
+        endpointName: 'testEndpoint',
+        state: testState,
+      });
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('errorSelector', () => {

--- a/src/redux-http/selectors.ts
+++ b/src/redux-http/selectors.ts
@@ -49,7 +49,9 @@ export const beccaccinoSelector = (input: BaseSelectorInput): Array<SelectorOutp
 
 export const resultSelector = (input: SelectorInput): Array<any> => beccaccinoSelector({
   ...input,
-  responseMapper: (_, r: any) => r ? r.response : undefined,
+  responseMapper: (meta: any, r: any) => r
+    && !meta.isLoading
+    && meta.success ? r.response : undefined,
 });
 
 export const errorSelector = (input: SelectorInput): Array<any> => beccaccinoSelector({


### PR DESCRIPTION
The result selector had no knowledge of the error/loading status of response.
We encountered a bug when a request has an error and the resultSelector is populated with the response.

Now only the errorSelector can give a reponse to an api call with error.

Integration & unit test attached.

cc @sciamp 